### PR TITLE
Data Driven / Cross Platform Changes

### DIFF
--- a/src/main/java/net/countered/terrainslabs/block/ModBlockTags.java
+++ b/src/main/java/net/countered/terrainslabs/block/ModBlockTags.java
@@ -10,4 +10,7 @@ import static net.countered.terrainslabs.TerrainSlabs.MOD_ID;
 public class ModBlockTags {
     public static final TagKey<Block> DOUBLE_TALL_PLANTS =
             TagKey.of(RegistryKeys.BLOCK, new Identifier(MOD_ID, "double_tall_plants"));
+
+    public static final TagKey<Block> SOIL_SLAB_BLOCKS =
+            TagKey.of(RegistryKeys.BLOCK, new Identifier(MOD_ID, "soil_slabs"));
 }

--- a/src/main/java/net/countered/terrainslabs/block/ModBlockTags.java
+++ b/src/main/java/net/countered/terrainslabs/block/ModBlockTags.java
@@ -1,0 +1,13 @@
+package net.countered.terrainslabs.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.util.Identifier;
+
+import static net.countered.terrainslabs.TerrainSlabs.MOD_ID;
+
+public class ModBlockTags {
+    public static final TagKey<Block> DOUBLE_TALL_PLANTS =
+            TagKey.of(RegistryKeys.BLOCK, new Identifier(MOD_ID, "double_tall_plants"));
+}

--- a/src/main/java/net/countered/terrainslabs/block/ModSlabsMap.java
+++ b/src/main/java/net/countered/terrainslabs/block/ModSlabsMap.java
@@ -1,11 +1,7 @@
 package net.countered.terrainslabs.block;
 
-import net.fabricmc.fabric.api.block.v1.FabricBlock;
-import net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider;
-import net.fabricmc.loader.impl.launch.knot.FabricGlobalPropertyService;
 import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 

--- a/src/main/java/net/countered/terrainslabs/callbacks/RegisterCallbacks.java
+++ b/src/main/java/net/countered/terrainslabs/callbacks/RegisterCallbacks.java
@@ -201,7 +201,7 @@ public class RegisterCallbacks {
             if (MyModConfig.enableSnowOnSlabs) {
                 BlockState snowState = ModBlocksRegistry.SNOW_ON_TOP.getDefaultState();
                 setBlockWithoutUpdates(worldChunk, blockAbovePos, snowState);
-                if (SlabFeatureLogic.SOIL_SLAB_BLOCKS.contains(slabState.getBlock()) && !slabState.isOf(ModBlocksRegistry.PATH_SLAB)) {
+                if (slabState.getProperties().contains(Properties.SNOWY)) {//SlabFeatureLogic.SOIL_SLAB_BLOCKS.contains(slabState.getBlock()) && !slabState.isOf(ModBlocksRegistry.PATH_SLAB)) {
                     slabState = slabState.with(Properties.SNOWY, true);
                 }
             } else {

--- a/src/main/java/net/countered/terrainslabs/callbacks/RegisterCallbacks.java
+++ b/src/main/java/net/countered/terrainslabs/callbacks/RegisterCallbacks.java
@@ -6,7 +6,6 @@ import net.countered.terrainslabs.block.ModSlabsMap;
 import net.countered.terrainslabs.block.customslabs.specialslabs.CustomSlab;
 import net.countered.terrainslabs.config.MyModConfig;
 import net.countered.terrainslabs.persistence.SlabChunkAttachment;
-import net.countered.terrainslabs.worldgen.slabfeature.SlabFeatureLogic;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.minecraft.block.*;
@@ -33,8 +32,6 @@ import net.minecraft.world.chunk.ChunkSection;
 import net.minecraft.world.chunk.WorldChunk;
 
 import java.util.*;
-
-import static com.mojang.text2speech.Narrator.LOGGER;
 
 public class RegisterCallbacks {
     private static final Map<Item, Block> VEGETATION_ON_TOP_ITEMS = new HashMap<>();

--- a/src/main/java/net/countered/terrainslabs/callbacks/RegisterCallbacks.java
+++ b/src/main/java/net/countered/terrainslabs/callbacks/RegisterCallbacks.java
@@ -201,7 +201,7 @@ public class RegisterCallbacks {
             if (MyModConfig.enableSnowOnSlabs) {
                 BlockState snowState = ModBlocksRegistry.SNOW_ON_TOP.getDefaultState();
                 setBlockWithoutUpdates(worldChunk, blockAbovePos, snowState);
-                if (slabState.getProperties().contains(Properties.SNOWY)) {//SlabFeatureLogic.SOIL_SLAB_BLOCKS.contains(slabState.getBlock()) && !slabState.isOf(ModBlocksRegistry.PATH_SLAB)) {
+                if (slabState.getProperties().contains(Properties.SNOWY)) {
                     slabState = slabState.with(Properties.SNOWY, true);
                 }
             } else {

--- a/src/main/java/net/countered/terrainslabs/callbacks/RegisterCallbacks.java
+++ b/src/main/java/net/countered/terrainslabs/callbacks/RegisterCallbacks.java
@@ -1,5 +1,6 @@
 package net.countered.terrainslabs.callbacks;
 
+import net.countered.terrainslabs.block.ModBlockTags;
 import net.countered.terrainslabs.block.ModBlocksRegistry;
 import net.countered.terrainslabs.block.ModSlabsMap;
 import net.countered.terrainslabs.block.customslabs.specialslabs.CustomSlab;
@@ -14,12 +15,14 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.registry.Registries;
 import net.minecraft.registry.tag.BlockTags;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.state.property.Properties;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
@@ -30,6 +33,8 @@ import net.minecraft.world.chunk.ChunkSection;
 import net.minecraft.world.chunk.WorldChunk;
 
 import java.util.*;
+
+import static com.mojang.text2speech.Narrator.LOGGER;
 
 public class RegisterCallbacks {
     private static final Map<Item, Block> VEGETATION_ON_TOP_ITEMS = new HashMap<>();
@@ -47,6 +52,11 @@ public class RegisterCallbacks {
         VEGETATION_ON_TOP_ITEMS.put(Items.SEAGRASS, ModBlocksRegistry.SEAGRASS_ON_TOP);
     }
 
+    public static void putVegetaitonOnTopItemFromString( String keyMod, String keyName, String valueMod, String valueName ) {
+        Item item = Registries.ITEM.get( Identifier.of( keyMod, keyName ) );
+        Block onTopBlock = Registries.BLOCK.get( Identifier.of( valueMod, valueName ) );
+        VEGETATION_ON_TOP_ITEMS.put( item, onTopBlock );
+    }
 
     public static void registerCallbacks() {
         registerPlaceOnTopCallback();
@@ -132,12 +142,6 @@ public class RegisterCallbacks {
         });
     }
 
-    private static final Set<Block> doubleTallPlants = new HashSet<>();
-    static {
-        doubleTallPlants.add(Blocks.TALL_GRASS);
-        doubleTallPlants.add(Blocks.LARGE_FERN);
-        doubleTallPlants.add(Blocks.TALL_SEAGRASS);
-    }
     private static void placeBottomSlab(WorldChunk worldChunk, BlockPos placePos) {
         BlockPos blockBelowPos = placePos.down();
         BlockPos blockAbovePos = placePos.up();
@@ -146,7 +150,7 @@ public class RegisterCallbacks {
         BlockState blockBelowState = worldChunk.getBlockState(blockBelowPos);
 
         if (!(currentBlockState.isOf(Blocks.AIR) || currentBlockState.isOf(Blocks.WATER) || currentBlockState.isOf(Blocks.CAVE_AIR) || currentBlockState.isOf(Blocks.VOID_AIR)  || currentBlockState.isOf(Blocks.LAVA))
-                && !doubleTallPlants.contains(currentBlockState.getBlock()) && !currentBlockState.isIn(BlockTags.TALL_FLOWERS)
+                && !currentBlockState.isIn(ModBlockTags.DOUBLE_TALL_PLANTS) && !currentBlockState.isIn(BlockTags.TALL_FLOWERS)
                 && !ModSlabsMap.ON_TOP_VEGETATION_BLOCKS_MAP.containsKey(currentBlockState.getBlock()) && !currentBlockState.isOf(Blocks.SNOW)) {
             return;
         }
@@ -174,7 +178,7 @@ public class RegisterCallbacks {
         ChunkSection abovePosSection = worldChunk.getSection(sectionIndex);
 
         // remove double tall plants
-        if (doubleTallPlants.contains(currentBlockState.getBlock()) || currentBlockState.isIn(BlockTags.TALL_FLOWERS)) {
+        if (currentBlockState.isIn(ModBlockTags.DOUBLE_TALL_PLANTS) || currentBlockState.isIn(BlockTags.TALL_FLOWERS)) {
             if (currentBlockState.isOf(Blocks.TALL_SEAGRASS)) {
                 setBlockWithoutUpdates(worldChunk, blockAbovePos, Blocks.WATER.getDefaultState());
                 blockAboveState = Blocks.WATER.getDefaultState();

--- a/src/main/java/net/countered/terrainslabs/mixin/BlockViewMixin.java
+++ b/src/main/java/net/countered/terrainslabs/mixin/BlockViewMixin.java
@@ -1,0 +1,63 @@
+package net.countered.terrainslabs.mixin;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import net.minecraft.block.BlockState;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.RaycastContext;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin( BlockView.class )
+public interface BlockViewMixin {
+
+    //
+    //
+
+    /**
+     * Injects into lambda responsible for the "blockHitFactory" in the core raytrace method of BlockView.
+     * Adds on a check for whether the block above the raytrace target is seen in front of the actual voxel targeted.
+     * This check allows "onTop" slab blocks to be targeted correctly.
+     * @param innerContext RaycastContext
+     * @param pos BlockPos
+     * @param cir CallbackInfoReturnable
+     * @param blockHitResult BlockHitResult
+     * @param blockHitResult2 BlockHitResult for fluid
+     */
+    @Inject( method = "method_17743", at = @At( "RETURN" ), cancellable = true)
+    private void onBlockHitFactory(
+            RaycastContext innerContext,
+            BlockPos pos,
+            CallbackInfoReturnable<BlockHitResult> cir,
+            @Local( ordinal = 0 ) BlockHitResult blockHitResult,
+            @Local( ordinal = 1 ) BlockHitResult blockHitResult2
+    ) {
+        BlockPos abovePos = new BlockPos( pos.getX(), pos.getY() + 1, pos.getZ() );
+        BlockState blockStateAbove = this.getBlockState( abovePos );
+        VoxelShape voxelShape3 = innerContext.getBlockShape( blockStateAbove, (BlockView) this, abovePos );
+        BlockHitResult blockHitResultAbove = this.raycastBlock( innerContext.getStart(), innerContext.getEnd(), abovePos, voxelShape3, blockStateAbove );
+        double f = blockHitResultAbove == null ? Double.MAX_VALUE : innerContext.getStart().squaredDistanceTo(blockHitResultAbove.getPos());
+
+        double d = blockHitResult == null ? Double.MAX_VALUE : innerContext.getStart().squaredDistanceTo(blockHitResult.getPos());
+        double e = blockHitResult2 == null ? Double.MAX_VALUE : innerContext.getStart().squaredDistanceTo(blockHitResult2.getPos());
+
+        if ( f <= d && f <= e ) {
+            cir.setReturnValue(blockHitResultAbove);
+        }
+    }
+
+    @Shadow
+    BlockState getBlockState(BlockPos pos);
+
+    @Shadow
+    default BlockHitResult raycastBlock(Vec3d start, Vec3d end, BlockPos pos, VoxelShape shape, BlockState state) {
+        return null;
+    }
+
+}

--- a/src/main/java/net/countered/terrainslabs/mixin/BlockViewMixin.java
+++ b/src/main/java/net/countered/terrainslabs/mixin/BlockViewMixin.java
@@ -17,9 +17,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin( BlockView.class )
 public interface BlockViewMixin {
 
-    //
-    //
-
     /**
      * Injects into lambda responsible for the "blockHitFactory" in the core raytrace method of BlockView.
      * Adds on a check for whether the block above the raytrace target is seen in front of the actual voxel targeted.

--- a/src/main/java/net/countered/terrainslabs/worldgen/slabfeature/SlabFeatureLogic.java
+++ b/src/main/java/net/countered/terrainslabs/worldgen/slabfeature/SlabFeatureLogic.java
@@ -5,7 +5,6 @@ import net.countered.terrainslabs.block.ModBlocksRegistry;
 import net.countered.terrainslabs.block.ModSlabsMap;
 import net.countered.terrainslabs.config.MyModConfig;
 import net.countered.terrainslabs.persistence.SlabChunkAttachment;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.SlabBlock;
@@ -22,7 +21,6 @@ import net.minecraft.world.gen.feature.util.FeatureContext;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class SlabFeatureLogic extends Feature<DefaultFeatureConfig> {
 

--- a/src/main/java/net/countered/terrainslabs/worldgen/slabfeature/SlabFeatureLogic.java
+++ b/src/main/java/net/countered/terrainslabs/worldgen/slabfeature/SlabFeatureLogic.java
@@ -30,13 +30,6 @@ public class SlabFeatureLogic extends Feature<DefaultFeatureConfig> {
         super(codec);
     }
 
-    public static final Set<Block> SOIL_SLAB_BLOCKS = Set.of(
-            ModBlocksRegistry.GRASS_SLAB,
-            ModBlocksRegistry.PODZOL_SLAB,
-            ModBlocksRegistry.MYCELIUM_SLAB,
-            ModBlocksRegistry.PATH_SLAB
-    );
-
     @Override
     public boolean generate(FeatureContext<DefaultFeatureConfig> context){
         if (MyModConfig.enableSlabGeneration) {

--- a/src/main/resources/data/terrainslabs/tags/blocks/double_tall_plants.json
+++ b/src/main/resources/data/terrainslabs/tags/blocks/double_tall_plants.json
@@ -1,0 +1,7 @@
+{
+  "values": [
+    "minecraft:tall_grass",
+    "minecraft:large_fern",
+    "minecraft:tall_seagrass"
+  ]
+}

--- a/src/main/resources/data/terrainslabs/tags/blocks/soil_slabs.json
+++ b/src/main/resources/data/terrainslabs/tags/blocks/soil_slabs.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "terrainslabs:grass_slab",
+    "terrainslabs:podzol_slab",
+    "terrainslabs:mycelium_slab",
+    "terrainslabs:path_slab"
+  ]
+}

--- a/src/main/resources/terrainslabs.mixins.json
+++ b/src/main/resources/terrainslabs.mixins.json
@@ -3,6 +3,7 @@
   "package": "net.countered.terrainslabs.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "BlockViewMixin",
     "ShovelItemMixin"
   ],
   "injectors": {


### PR DESCRIPTION
 - Converted sets "SOIL_SLAB_BLOCKS" and "doubleTallPlants" to tags and replaced relevant calls.
 - Replaced Snowy property handling with a check for the property rather than the block type.
 - Added cross platform "put" method for the "VEGETATION_ON_TOP_ITEMS" map
 - Removed unused imports