### PR TITLE
Update mod to Minecraft 1.21.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.9-SNAPSHOT'
+	id 'fabric-loom' version '1.13.6'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.4
-yarn_mappings=1.21.4+build.8
-loader_version=0.16.10
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
+loader_version=0.18.4
 
 # Mod Properties
-mod_version=1.5.1
+mod_version=1.5.2
 maven_group=net.countered.terrainslabs
 archives_base_name=countereds_terrain_slabs
-midnightlib_version = 1.6.6-fabric
+midnightlib_version = 1.9.1+1.21.8-fabric
 
 # Dependencies
-fabric_version=0.115.0+1.21.4
+fabric_version=0.134.0+1.21.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/countered/datagen/ModBlockTagsProvider.java
+++ b/src/main/java/net/countered/datagen/ModBlockTagsProvider.java
@@ -15,7 +15,7 @@ public class ModBlockTagsProvider extends FabricTagProvider.BlockTagProvider {
 
     @Override
     protected void configure(RegistryWrapper.WrapperLookup wrapperLookup) {
-        this.getOrCreateTagBuilder(BlockTags.SLABS)
+        this.valueLookupBuilder(BlockTags.SLABS)
                 .add(ModBlocksRegistry.DIRT_SLAB)
                 .add(ModBlocksRegistry.MUD_SLAB)
                 .add(ModBlocksRegistry.COARSE_SLAB)
@@ -59,7 +59,7 @@ public class ModBlockTagsProvider extends FabricTagProvider.BlockTagProvider {
                 .add(ModBlocksRegistry.CUSTOM_BLACKSTONE_SLAB)
                 .add(ModBlocksRegistry.ENDSTONE_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.SHOVEL_MINEABLE)
+        this.valueLookupBuilder(BlockTags.SHOVEL_MINEABLE)
                 .add(ModBlocksRegistry.DIRT_SLAB)
                 .add(ModBlocksRegistry.MUD_SLAB)
                 .add(ModBlocksRegistry.COARSE_SLAB)
@@ -77,7 +77,7 @@ public class ModBlockTagsProvider extends FabricTagProvider.BlockTagProvider {
                 .add(ModBlocksRegistry.SOUL_SAND_SLAB)
                 .add(ModBlocksRegistry.SOUL_SOIL_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.PICKAXE_MINEABLE)
+        this.valueLookupBuilder(BlockTags.PICKAXE_MINEABLE)
                 .add(ModBlocksRegistry.PACKED_ICE_SLAB)
                 .add(ModBlocksRegistry.DEEPSLATE_SLAB)
                 .add(ModBlocksRegistry.TERRACOTTA_SLAB)
@@ -102,43 +102,43 @@ public class ModBlockTagsProvider extends FabricTagProvider.BlockTagProvider {
                 .add(ModBlocksRegistry.BASALT_SLAB)
                 .add(ModBlocksRegistry.ENDSTONE_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.HOE_MINEABLE)
+        this.valueLookupBuilder(BlockTags.HOE_MINEABLE)
                 .add(ModBlocksRegistry.MOSS_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.AXE_MINEABLE)
+        this.valueLookupBuilder(BlockTags.AXE_MINEABLE)
                 .add(ModBlocksRegistry.DEAD_BUSH_ON_TOP)
                 .add(ModBlocksRegistry.SHORT_GRASS_ON_TOP)
                 .add(ModBlocksRegistry.FERN_ON_TOP)
                 .add(ModBlocksRegistry.BROWN_MUSHROOM_ON_TOP)
                 .add(ModBlocksRegistry.RED_MUSHROOM_ON_TOP);
 
-        this.getOrCreateTagBuilder(BlockTags.SWORD_EFFICIENT)
+        this.valueLookupBuilder(BlockTags.SWORD_EFFICIENT)
                 .add(ModBlocksRegistry.DEAD_BUSH_ON_TOP)
                 .add(ModBlocksRegistry.BROWN_MUSHROOM_ON_TOP)
                 .add(ModBlocksRegistry.RED_MUSHROOM_ON_TOP)
                 .add(ModBlocksRegistry.SHORT_GRASS_ON_TOP)
                 .add(ModBlocksRegistry.FERN_ON_TOP);
 
-        this.getOrCreateTagBuilder(BlockTags.CAMEL_SAND_STEP_SOUND_BLOCKS).add(ModBlocksRegistry.SAND_SLAB);
+        this.valueLookupBuilder(BlockTags.CAMEL_SAND_STEP_SOUND_BLOCKS).add(ModBlocksRegistry.SAND_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.SMELTS_TO_GLASS).add(ModBlocksRegistry.SAND_SLAB, ModBlocksRegistry.RED_SAND_SLAB);
+        this.valueLookupBuilder(BlockTags.SMELTS_TO_GLASS).add(ModBlocksRegistry.SAND_SLAB, ModBlocksRegistry.RED_SAND_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.PARROTS_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB);
+        this.valueLookupBuilder(BlockTags.PARROTS_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.ANIMALS_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB);
+        this.valueLookupBuilder(BlockTags.ANIMALS_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.VALID_SPAWN).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.PODZOL_SLAB);
+        this.valueLookupBuilder(BlockTags.VALID_SPAWN).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.PODZOL_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.AXOLOTLS_SPAWNABLE_ON).add(ModBlocksRegistry.CLAY_SLAB);
+        this.valueLookupBuilder(BlockTags.AXOLOTLS_SPAWNABLE_ON).add(ModBlocksRegistry.CLAY_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.RABBITS_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.SNOW_SLAB, ModBlocksRegistry.SAND_SLAB);
+        this.valueLookupBuilder(BlockTags.RABBITS_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.SNOW_SLAB, ModBlocksRegistry.SAND_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.GOATS_SPAWNABLE_ON) //needs improvement
+        this.valueLookupBuilder(BlockTags.GOATS_SPAWNABLE_ON) //needs improvement
                 .add(ModBlocksRegistry.CUSTOM_STONE_SLAB, ModBlocksRegistry.SNOW_SLAB, ModBlocksRegistry.PACKED_ICE_SLAB, ModBlocksRegistry.GRAVEL_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.SNOW).add(ModBlocksRegistry.SNOW_SLAB).add(ModBlocksRegistry.SNOW_ON_TOP);
+        this.valueLookupBuilder(BlockTags.SNOW).add(ModBlocksRegistry.SNOW_SLAB).add(ModBlocksRegistry.SNOW_ON_TOP);
 
-        this.getOrCreateTagBuilder(BlockTags.SCULK_REPLACEABLE)
+        this.valueLookupBuilder(BlockTags.SCULK_REPLACEABLE)
                 .add(ModBlocksRegistry.CUSTOM_STONE_SLAB)
                 .add(ModBlocksRegistry.DIRT_SLAB)
                 .add(ModBlocksRegistry.TERRACOTTA_SLAB)  //need extension
@@ -149,7 +149,7 @@ public class ModBlockTagsProvider extends FabricTagProvider.BlockTagProvider {
                 .add(ModBlocksRegistry.CUSTOM_SANDSTONE_SLAB);
 
 
-        this.getOrCreateTagBuilder(BlockTags.AZALEA_ROOT_REPLACEABLE)
+        this.valueLookupBuilder(BlockTags.AZALEA_ROOT_REPLACEABLE)
                 .add(ModBlocksRegistry.CUSTOM_STONE_SLAB)
                 .add(ModBlocksRegistry.DIRT_SLAB)
                 .add(ModBlocksRegistry.TERRACOTTA_SLAB)  //need extension
@@ -159,35 +159,36 @@ public class ModBlockTagsProvider extends FabricTagProvider.BlockTagProvider {
                 .add(ModBlocksRegistry.SAND_SLAB)
                 .add(ModBlocksRegistry.SNOW_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.SNIFFER_DIGGABLE_BLOCK)
+        this.valueLookupBuilder(BlockTags.SNIFFER_DIGGABLE_BLOCK)
                 .add(ModBlocksRegistry.DIRT_SLAB, ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.PODZOL_SLAB, ModBlocksRegistry.COARSE_SLAB, ModBlocksRegistry.MOSS_SLAB, ModBlocksRegistry.MUD_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.WOLVES_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.SNOW_SLAB, ModBlocksRegistry.COARSE_SLAB, ModBlocksRegistry.PODZOL_SLAB);
+        this.valueLookupBuilder(BlockTags.WOLVES_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.SNOW_SLAB, ModBlocksRegistry.COARSE_SLAB, ModBlocksRegistry.PODZOL_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.FOXES_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.SNOW_SLAB, ModBlocksRegistry.PODZOL_SLAB, ModBlocksRegistry.COARSE_SLAB);
+        this.valueLookupBuilder(BlockTags.FOXES_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.SNOW_SLAB, ModBlocksRegistry.PODZOL_SLAB, ModBlocksRegistry.COARSE_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.ARMADILLO_SPAWNABLE_ON)
+        this.valueLookupBuilder(BlockTags.ARMADILLO_SPAWNABLE_ON)
                 .add(ModBlocksRegistry.RED_SAND_SLAB, ModBlocksRegistry.COARSE_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.MANGROVE_LOGS_CAN_GROW_THROUGH)
+        this.valueLookupBuilder(BlockTags.MANGROVE_LOGS_CAN_GROW_THROUGH)
                 .add(ModBlocksRegistry.MUD_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.MANGROVE_ROOTS_CAN_GROW_THROUGH)
+        this.valueLookupBuilder(BlockTags.MANGROVE_ROOTS_CAN_GROW_THROUGH)
                 .add(ModBlocksRegistry.MUD_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.FROGS_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.MUD_SLAB);
+        this.valueLookupBuilder(BlockTags.FROGS_SPAWNABLE_ON).add(ModBlocksRegistry.GRASS_SLAB, ModBlocksRegistry.MUD_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.UNDERWATER_BONEMEALS).add(ModBlocksRegistry.SEAGRASS_ON_TOP);
+        this.valueLookupBuilder(BlockTags.UNDERWATER_BONEMEALS).add(ModBlocksRegistry.SEAGRASS_ON_TOP);
 
-        this.getOrCreateTagBuilder(BlockTags.SOUL_SPEED_BLOCKS).add(ModBlocksRegistry.SOUL_SAND_SLAB, ModBlocksRegistry.SOUL_SOIL_SLAB);
+        this.valueLookupBuilder(BlockTags.SOUL_SPEED_BLOCKS).add(ModBlocksRegistry.SOUL_SAND_SLAB, ModBlocksRegistry.SOUL_SOIL_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.INFINIBURN_OVERWORLD).add(ModBlocksRegistry.NETHERRACK_SLAB);
+        this.valueLookupBuilder(BlockTags.INFINIBURN_OVERWORLD).add(ModBlocksRegistry.NETHERRACK_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.MUSHROOM_GROW_BLOCK).add(ModBlocksRegistry.MYCELIUM_SLAB).add(ModBlocksRegistry.PODZOL_SLAB).add(ModBlocksRegistry.CRIMSON_NYLIUM_SLAB).add(ModBlocksRegistry.WARPED_NYLIUM_SLAB);
+        this.valueLookupBuilder(BlockTags.MUSHROOM_GROW_BLOCK).add(ModBlocksRegistry.MYCELIUM_SLAB).add(ModBlocksRegistry.PODZOL_SLAB).add(ModBlocksRegistry.CRIMSON_NYLIUM_SLAB).add(ModBlocksRegistry.WARPED_NYLIUM_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.DRAGON_IMMUNE).add(ModBlocksRegistry.ENDSTONE_SLAB);
+        this.valueLookupBuilder(BlockTags.DRAGON_IMMUNE).add(ModBlocksRegistry.ENDSTONE_SLAB);
 
-        this.getOrCreateTagBuilder(BlockTags.NYLIUM).add(ModBlocksRegistry.CRIMSON_NYLIUM_SLAB, ModBlocksRegistry.WARPED_NYLIUM_SLAB);
+        this.valueLookupBuilder(BlockTags.NYLIUM).add(ModBlocksRegistry.CRIMSON_NYLIUM_SLAB, ModBlocksRegistry.WARPED_NYLIUM_SLAB);
 
     }
 }
+

--- a/src/main/java/net/countered/terrainslabs/TerrainSlabsClient.java
+++ b/src/main/java/net/countered/terrainslabs/TerrainSlabsClient.java
@@ -1,20 +1,19 @@
 package net.countered.terrainslabs;
 
 import net.fabricmc.api.*;
-import net.fabricmc.fabric.api.blockrenderlayer.v1.*;
 import net.fabricmc.fabric.api.client.rendering.v1.*;
 import net.minecraft.block.*;
 import net.minecraft.client.color.block.*;
 import net.minecraft.client.color.world.*;
 import net.minecraft.client.render.*;
-import net.minecraft.world.biome.*;
+import net.minecraft.world.biome.GrassColors;
 
 import static net.countered.terrainslabs.block.ModBlocksRegistry.*;
 
 public class TerrainSlabsClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        BlockRenderLayerMap.INSTANCE.putBlocks(RenderLayer.getCutoutMipped(), getCutoutMippedBlocks());
+        BlockRenderLayerMap.putBlocks(BlockRenderLayer.CUTOUT_MIPPED, getCutoutMippedBlocks());
         ColorProviderRegistry.BLOCK.register(colorBlockOrDefaultProvider(), getTintedBlocks());
     }
 

--- a/src/main/java/net/countered/terrainslabs/block/customslabs/soilslabs/MyceliumSlab.java
+++ b/src/main/java/net/countered/terrainslabs/block/customslabs/soilslabs/MyceliumSlab.java
@@ -116,7 +116,7 @@ public class MyceliumSlab extends CustomSlab {
     public void randomDisplayTick(BlockState state, World world, BlockPos pos, Random random) {
         super.randomDisplayTick(state, world, pos, random);
         if (random.nextInt(10) == 0) {
-            world.addParticle(
+            world.addParticleClient(
                     ParticleTypes.MYCELIUM, (double)pos.getX() + random.nextDouble(), (double)pos.getY() + 1.1/2, (double)pos.getZ() + random.nextDouble(), 0.0, 0.0, 0.0
             );
         }

--- a/src/main/java/net/countered/terrainslabs/block/customslabs/specialslabs/GravityAffectedSlab.java
+++ b/src/main/java/net/countered/terrainslabs/block/customslabs/specialslabs/GravityAffectedSlab.java
@@ -3,7 +3,6 @@ package net.countered.terrainslabs.block.customslabs.specialslabs;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.LandingBlock;
 import net.minecraft.block.enums.SlabType;
 import net.minecraft.entity.FallingBlockEntity;
 import net.minecraft.fluid.FluidState;
@@ -26,7 +25,7 @@ import net.minecraft.world.WorldView;
 import net.minecraft.world.tick.ScheduledTickView;
 import org.jetbrains.annotations.Nullable;
 
-public class GravityAffectedSlab extends CustomSlab implements LandingBlock {
+public class GravityAffectedSlab extends CustomSlab {
 
     public GravityAffectedSlab(Settings settings) {
         super(settings);
@@ -118,19 +117,5 @@ public class GravityAffectedSlab extends CustomSlab implements LandingBlock {
         }
     }
 
-    @Override
-    public void onDestroyedOnLanding(World world, BlockPos pos, FallingBlockEntity fallingBlockEntity) {
-        LandingBlock.super.onDestroyedOnLanding(world, pos, fallingBlockEntity);
-        if (fallingBlockEntity.getBlockState().get(TYPE) == SlabType.DOUBLE) {
-            dropStack(world, pos, new ItemStack(this.asItem()));
-        }
-    }
-    @Override
-    public void onLanding(World world, BlockPos pos, BlockState fallingBlockState, BlockState currentStateInPos, FallingBlockEntity fallingBlockEntity) {
-        LandingBlock.super.onLanding(world, pos, fallingBlockState, currentStateInPos, fallingBlockEntity);
-        if (fallingBlockState.get(TYPE) == SlabType.TOP) {
-            world.setBlockState(pos, this.getDefaultState().with(Properties.SLAB_TYPE, SlabType.BOTTOM));
-        }
-    }
 }
 

--- a/src/main/java/net/countered/terrainslabs/block/ontopofslabs/DeadBushOnTop.java
+++ b/src/main/java/net/countered/terrainslabs/block/ontopofslabs/DeadBushOnTop.java
@@ -5,10 +5,10 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 
-public class DeadBushOnTop extends DeadBushBlock {
+public class DeadBushOnTop extends BushBlock {
     protected static final VoxelShape SHAPE = Block.createCuboidShape(2.0, -8.0, 2.0, 14.0, 5.0, 14.0);
 
-    public DeadBushOnTop(Settings settings) {
+    public DeadBushOnTop(AbstractBlock.Settings settings) {
         super(settings);
     }
     @Override

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
 	"schemaVersion": 1,
 	"id": "terrainslabs",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"name": "Countered's Terrain Slabs",
 	"description": "A Minecraft mod designed to smooth out terrain using custom slabs, improving the world generation and overall feel.",
 	"authors": [
@@ -9,7 +9,7 @@
 	],
 	"contact": {
 		"homepage": "https://fabricmc.net/",
-		"sources": "https://github.com/FabricMC/fabric-example-mod"
+		"sources": "https://github.com/Coun7ered/terrain-slabs-mod"
 	},
 	"license": "CC0-1.0",
 	"icon": "assets/terrainslabs/icon.png",
@@ -30,7 +30,7 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.5",
-		"minecraft": "~1.21.4",
+		"minecraft": "~1.21.8",
 		"java": ">=21",
 		"fabric-api": "*"
 	},


### PR DESCRIPTION
Summary: update to Minecraft 1.21.8, bump Fabric/Yarn/Loader versions, move to Loom 1.13.6 with Gradle 8.14, and fix 1.21.8 API changes. Verification: gradlew clean build succeeds on Java 21 and produces countereds_terrain_slabs-1.5.2.jar.